### PR TITLE
Fix hook_timeScale crash on Unity 2022.3+ (icall stub codegen change)

### DIFF
--- a/LuckySpeeder.c
+++ b/LuckySpeeder.c
@@ -27,6 +27,7 @@ SOFTWARE.
 
 #include "LuckySpeeder.h"
 #include "fishhook.h"
+#include <dlfcn.h>
 #include <mach-o/dyld.h>
 #include <mach-o/getsect.h>
 #include <os/lock.h>
@@ -37,7 +38,6 @@ SOFTWARE.
 #if !TARGET_OS_TV
 #include "hwbphook.h"
 #include "port_clock_gettime.h"
-#include <dlfcn.h>
 #endif
 
 static float timeScale_speed = 1.0;
@@ -118,17 +118,22 @@ int hook_timeScale(void) {
   if (*(uintptr_t *)(code_section_address + function_data_offset)) {
     original_timeScale = *(void (**)(float))(function_data_offset + code_section_address);
   } else {
-    uint32_t instruction_operand = *(uint32_t *)(il2cpp_section_base + 8);
-    uint8_t *code_section_start = (uint8_t *)(il2cpp_section_base + 8);
-    uintptr_t instruction_offset = (4 * instruction_operand) & 0xFFFFFFC;
-    uintptr_t address_offset = (4 * (instruction_operand & 0x3FFFFFF)) | 0xFFFFFFFFF0000000LL;
-
-    if (((4 * instruction_operand) & 0x8000000) != 0)
-      function_offset = address_offset;
-    else
-      function_offset = instruction_offset;
-
-    original_timeScale = (void (*)(float))((uintptr_t (*)(void *))&code_section_start[function_offset])(time_scale_function_address);
+    typedef void *(*resolve_icall_t)(const char *);
+    resolve_icall_t resolve_icall = (resolve_icall_t)dlsym(RTLD_DEFAULT, "il2cpp_resolve_icall");
+    if (resolve_icall) {
+      original_timeScale = (void (*)(float))resolve_icall((const char *)time_scale_function_address);
+    } else {
+      for (int i = 2; i < 10; i++) {
+        uint32_t bl_candidate = *(uint32_t *)(il2cpp_section_base + i * 4);
+        if ((bl_candidate & 0xFC000000) != 0x94000000) continue;
+        int32_t imm26 = bl_candidate & 0x3FFFFFF;
+        if (imm26 & 0x2000000) imm26 |= (int32_t)0xFC000000;
+        uintptr_t bl_addr = il2cpp_section_base + (uintptr_t)i * 4;
+        uintptr_t target = bl_addr + (intptr_t)imm26 * 4;
+        original_timeScale = (void (*)(float))((resolve_icall_t)target)((const char *)time_scale_function_address);
+        break;
+      }
+    }
   }
 
   if (original_timeScale) {


### PR DESCRIPTION
## Summary

Heart mode (`hook_timeScale`) crashes on games built with **Unity 2022.3+** when the icall cache slot is still NULL (i.e., `Time.set_timeScale` has not yet been called before the hook is activated). Confirmed on Unity 2022.3.62f2.

## Root Cause

Unity 2022.3 changed IL2CPP's code generation for icall (internal call) stubs. The lazy resolver stub now saves float arguments before calling `il2cpp_resolve_icall`:

**Old pattern** (what the code expected):
```
ADRP X0, <string_page>        ; +0
ADD  X0, X0, #imm             ; +4  load method name string
BL   il2cpp_resolve_icall      ; +8  ← code hardcodes this offset
```

**New pattern** (Unity 2022.3+):
```
ADRP X0, <string_page>        ; +0
ADD  X0, X0, #imm             ; +4  load method name string
FMOV S8, S0                   ; +8  save float arg (NEW!)
BL   il2cpp_resolve_icall      ; +12 ← BL moved here
FMOV S0, S8                   ; +16 restore float arg
```

The else branch at line 121 reads the instruction at `il2cpp_section_base + 8` and decodes it as a `BL`. But it's now a `FMOV` (`0x1e204008`), which gets decoded as a garbage branch offset (`0xfffffffffc407cb4`), causing an immediate crash when called.

## Fix

- **Primary**: Use `dlsym(RTLD_DEFAULT, "il2cpp_resolve_icall")` to find Unity's icall resolver directly and call it with the method signature string. This completely avoids instruction decoding and works regardless of Unity version or compiler optimizations.
- **Fallback**: If `il2cpp_resolve_icall` is not exported, scan forward from the ADRP+ADD for the first `BL` instruction (within 10 instructions) instead of hardcoding offset +8.
- **Include fix**: Moved `#include <dlfcn.h>` out of the `#if !TARGET_OS_TV` guard since `dlsym` is now used in `hook_timeScale` on all platforms.

## Changes

- `LuckySpeeder.c`: 1 file changed, 17 insertions, 12 deletions

## Testing

- Verified the string `UnityEngine.Time::set_timeScale(System.Single)` exists in the LoR 7.4 binary
- Confirmed `il2cpp_resolve_icall` symbol is present in the UnityFramework binary
- Disassembled the il2cpp section and confirmed the FMOV insertion at offset +8
- Build compiles cleanly with `build.sh arm64-apple-ios` (no warnings)
- Other modes (Spade/Club/Diamond/Star) are unaffected — they use different hooking mechanisms

